### PR TITLE
feat: Uninstall script with option to retain the persistent volume claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ or the following steps:
     kubectl create namespace pacman
     kubectl create -n pacman -f pacman-tanzu/
 
+## Uninstall
+Run file `./pacman-uninstall.sh`. This will delete all objects created by `./pacman-install.sh`
+
+Alternatively, run `./pacman-uninstall.sh keeppvc`. This will delete all objects except for the pacman namespace and the persistent volume claim. You can use this to demonstrate persistence of the MongoDB data by installing, playing a game and recording a high score, then unininstalling with the `keeppvc` argument. You can then run the installation again and the high score will persist.
+
 ## Architecture
 
 The application is made up of the following components:

--- a/pacman-uninstall.sh
+++ b/pacman-uninstall.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+kubectl delete -n pacman -f security/rbac.yaml
+kubectl delete -n pacman -f security/secret.yaml
+kubectl delete -n pacman -f deployments/mongo-deployment.yaml
+kubectl delete -n pacman -f deployments/pacman-deployment.yaml
+kubectl delete -n pacman -f services/mongo-service.yaml
+kubectl delete -n pacman -f services/pacman-service.yaml
+
+if [[ $# -gt 0  && "$1" == "keeppvc" ]]
+then
+    echo "Keeping namespace and persistent volume claim"
+else
+    kubectl delete -n pacman -f persistentvolumeclaim/mongo-pvc.yaml
+    kubectl delete namespace pacman
+fi


### PR DESCRIPTION
Adds an uninstall script to quickly remove the entire pacman configuration from a cluster. Optional 'keeppvc' argument to the script allows you to retain the namespace and persistent volume claim. Your high scores will be retained because the PVC is retained. This is a simple way to demonstrate persistence.

Signed-off-by: Patrick Kremer <pkremer@vmware.com>