### PR TITLE
Modernize base deployment and add Cilium demos catalogue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,57 @@
+name: lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yamllint
+        run: pip install yamllint
+      - name: Run yamllint
+        run: yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: disable, comments: disable, indentation: disable}}" .
+
+  kubeconform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | tar -xz kubeconform
+          sudo mv kubeconform /usr/local/bin/kubeconform
+
+      - name: Validate core manifests against Kubernetes 1.30
+        run: |
+          # Render RBAC template before validating.
+          export NAMESPACE=pacman-demo
+          envsubst < security/rbac.yaml > /tmp/rendered-rbac.yaml
+          # Exclude RBAC source (templated) and cilium-demos (requires CRD schemas).
+          git ls-files '*.yaml' '*.yml' \
+            | grep -v '^security/rbac.yaml$' \
+            | grep -v '^cilium-demos/' \
+            | grep -v '^\.github/' \
+            | grep -v '^kustomization.yaml$' \
+            | xargs kubeconform \
+                -kubernetes-version 1.30.0 \
+                -strict \
+                -summary \
+                -ignore-missing-schemas \
+                /tmp/rendered-rbac.yaml
+
+      - name: Validate Cilium CRDs (advisory)
+        continue-on-error: true
+        run: |
+          SCHEMA_LOCATIONS="default https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+          git ls-files 'cilium-demos/**/*.yaml' 2>/dev/null \
+            | xargs --no-run-if-empty kubeconform \
+                -kubernetes-version 1.30.0 \
+                -summary \
+                -ignore-missing-schemas \
+                -schema-location "$SCHEMA_LOCATIONS"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+*.swp
+*.swo
+*.tgz
+*.bak
+.idea/
+.vscode/
+.kube/
+kubeconfig
+kubeconfig.*

--- a/README.md
+++ b/README.md
@@ -1,63 +1,114 @@
 # Running Pac-Man on Kubernetes
 
-Pac-Man the classic arcade game - deployment files for VMware Tanzu Kubernetes and all other Kubernetes distributions.
+Extended deployment surface for the Pac-Man app maintained at
+[`saintdle/pacman`](https://github.com/saintdle/pacman). For a minimal,
+in-repo set of learning examples (a multi-role `Deployment`, a postgres
+example with a migration `Job`, Cilium L7 example, Prometheus and Tetragon
+overlays) see
+[`saintdle/pacman/k8s/examples`](https://github.com/saintdle/pacman/tree/master/k8s/examples).
 
-<img src="https://veducate.co.uk/wp-content/uploads/2021/09/Pac-Man-UI.jpg" width=45% height=45%>
+This repo layers on persistent storage, Pod Security Standards, install
+scripts, and a catalogue of Cilium demos.
 
-## Pre-Reqs
+<img src="https://veducate.co.uk/wp-content/uploads/2021/09/Pac-Man-UI.jpg" width="45%" height="45%">
 
-ServiceType: LoadBalancer must be available for external connectivity to the Pac-Man front-end, otherwise you'll need to make some changes to the files in the "services" folder.
+## Pre-requisites
 
-## Deployment
+- A Kubernetes cluster (any distribution). `ServiceType: LoadBalancer` is
+  recommended for external connectivity to the front-end. Without it, edit
+  `services/pacman-service.yaml` to use `NodePort` or `ClusterIP` and use
+  `kubectl port-forward`.
+- Pod Security Standards labels are applied to the install namespace by
+  `pacman-install.sh` (`enforce=baseline`, `audit/warn=restricted`). All
+  base manifests are written to comply with the `restricted` profile
+  (`runAsNonRoot`, dropped capabilities, `seccompProfile: RuntimeDefault`,
+  `allowPrivilegeEscalation: false`).
+- `bash`, `kubectl`, and `envsubst` on the local machine.
 
-### Using Helm to install
-````
-kubectl create namespace pacman
+## Image
 
+All manifests in this repo target `docker.io/saintdle/pacman`, pinned by
+digest (`sha256:d1c36678...`). The Cilium demos accept a `PACMAN_IMAGE`
+env var override.
+
+## Install (base mongo-backed deployment)
+
+```bash
+./pacman-install.sh                  # defaults to namespace pacman-demo
+NAMESPACE=my-ns ./pacman-install.sh  # custom namespace
+```
+
+The install is idempotent (uses `kubectl apply`). Re-running it picks up
+manifest changes without errors. RBAC is rendered against the chosen
+`$NAMESPACE` so the ClusterRoleBinding subject matches the namespace you
+installed into.
+
+## Uninstall
+
+```bash
+./pacman-uninstall.sh                 # removes everything including the PVC
+./pacman-uninstall.sh keeppvc         # keep the namespace and the PVC
+NAMESPACE=my-ns ./pacman-uninstall.sh
+```
+
+Use `keeppvc` to demonstrate Mongo persistence: install, play a game,
+record a high score, uninstall with `keeppvc`, install again, and the
+high score is still there.
+
+## Helm
+
+A Helm chart is published from
+[`saintdle/helm-charts`](https://github.com/saintdle/helm-charts):
+
+```bash
 helm repo add veducate https://saintdle.github.io/helm-charts/
-helm install pacman veducate/pacman -n pacman
-
-# You can see the available values by running
+helm install pacman veducate/pacman -n pacman-demo --create-namespace
 helm show values veducate/pacman
-````
-[Read this blog post](https://veducate.co.uk/how-to-create-helm-chart/) to learn how this Helm Chart was created.
+```
 
-### Using a Script for installation
-Clone repo and run ```chmod +X pacman-install.sh``` and then run file ```./pacman-install.sh```
+See [this blog post](https://veducate.co.uk/how-to-create-helm-chart/) for
+how the chart was authored.
 
-or the following steps:
+## Cilium demo suite
 
-    kubectl create namespace pacman
-    kubectl create -n pacman -f pacman-tanzu/
+The [`cilium-demos`](cilium-demos) directory contains kind-based demos for
+Cilium OSS, Hubble, Gateway API, Cluster Mesh, and Tetragon. The default
+namespace is `pacman-demo`.
 
-#### Uninstall using a Script
-Run file `./pacman-uninstall.sh`. This will delete all objects created by `./pacman-install.sh`
+```bash
+./cilium-demos/scripts/setup-single-kind.sh
+./cilium-demos/scripts/deploy-demo.sh microservices-east-west
+./cilium-demos/scripts/deploy-demo.sh load-simulation
+```
 
-Alternatively, run `./pacman-uninstall.sh keeppvc`. This will delete all objects except for the pacman namespace and the persistent volume claim. You can use this to demonstrate persistence of the MongoDB data by installing, playing a game and recording a high score, then unininstalling with the `keeppvc` argument. You can then run the installation again and the high score will persist.
+See [`cilium-demos/README.md`](cilium-demos/README.md) for the full
+catalogue and per-demo walk-throughs.
 
 ## Architecture
 
-The application is made up of the following components:
+```
+Namespace (pacman-demo)
+├── Secret               mongodb-users-secret
+├── ConfigMap            mongo-init   (mongo entrypoint user seed)
+├── PVC                  mongo-storage
+├── Deployment           mongo        (mongo:8, RWO PVC, Recreate strategy)
+├── Service              mongo        (ClusterIP, 27017)
+├── Deployment           pacman       (saintdle/pacman, /healthz, /readyz)
+└── Service              pacman       (LoadBalancer, 80 → 8080)
+```
 
-* Namespace
-* Deployment
-  * MongoDB Pod
-    * DB Authentication configured
-    * Attached to a PVC
-  * Pac-Man Pod
-    * Nodejs web front end that connects back to the MongoDB Pod by looking for the Pod DNS address internally.
-* RBAC Configuration for Pod Security and Service Account
-* Secret which holds the data for the MongoDB Usernames and Passwords to be configured
-* Service
-  * Type: LoadBalancer
-    * Used to balance traffic to the Pac-Man Pods
+ClusterRole / ClusterRoleBinding (cluster-scoped) grant `get/watch/list`
+on `pods` and `nodes` to the `default` ServiceAccount of the install
+namespace, used by the in-app location probe.
 
-<img src="https://i1.wp.com/veducate.co.uk/wp-content/uploads/2021/08/Pac-Man-Kubernetes-Diagram.jpg?w=483&ssl=1" width=50% height=50%>
+## Repository layout
 
-## Source
-
-These are modified files from the below github repo for the node.js version, which contain the necessary changes to run in VMware Tanzu Kubernetes Grid (TKG) such as updated api values and pod security policies (psp) with associated service accounts and RBAC.
-
-> <https://github.com/font/k8s-example-apps/tree/master/pacman-nodejs-app>
-
-Security changes to the deployment such as setting up mongodb auth were thanks to [Dav1x](https://github.com/dav1x/) you can find his [Pac-Man deployment for OpenShift here](https://github.com/dav1x/pacman-ocp).
+```
+deployments/             Mongo and Pac-Man Deployments
+services/                Mongo (ClusterIP) and Pac-Man (LoadBalancer) Services
+persistentvolumeclaim/   Mongo data PVC
+security/                RBAC (rendered at install time) and Secret
+cilium-demos/            kind-based Cilium / Hubble / Tetragon demos
+pacman-install.sh        Idempotent installer (NAMESPACE override supported)
+pacman-uninstall.sh      Uninstaller with optional `keeppvc`
+```

--- a/cilium-demos/README.md
+++ b/cilium-demos/README.md
@@ -1,0 +1,44 @@
+# Cilium demos for Pac-Man
+
+These demos use the Pac-Man app as a small but real Kubernetes workload for showing Cilium OSS, Hubble, Gateway API, Cluster Mesh, and Tetragon.
+
+Default image: `docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198`.
+Override it in scripts with `PACMAN_IMAGE=your-registry/your-image:tag`.
+
+## Prerequisites
+
+- `kind`
+- `kubectl`
+- `helm`
+- `cilium` CLI
+- Docker or another container runtime supported by kind
+
+## Quick start
+
+```bash
+./cilium-demos/scripts/setup-single-kind.sh
+./cilium-demos/scripts/deploy-demo.sh microservices-east-west
+```
+
+Then open Hubble UI or use:
+
+```bash
+cilium hubble port-forward &
+hubble observe --namespace pacman-demo --follow
+```
+
+## Demo index
+
+| Demo | What it shows |
+|------|---------------|
+| `microservices-east-west` | Real app roles talking over ClusterIP Services with Cilium L3/L4/L7 policy |
+| `grpc-grpcroute` | gRPC service exposure through Cilium Gateway API GRPCRoute |
+| `cluster-mesh-failover` | Dual-kind Cluster Mesh failover and global service flow observation |
+| `topology-aware-routing` | Kubernetes topology-aware routing hints surfaced by the app |
+| `canary-progressive-delivery` | Gateway API weighted routing with visible backend version/variant |
+| `load-simulation` | Synthetic frontend users and k6 volume load for scaling and balancing demos |
+| `fault-injection-resilience` | Gated app faults for resilience and observability demos |
+| `tetragon-enforcement` | Tetragon tracing and optional enforcement for lab-only app probes |
+| `runtime-security-incident` | Safe incident story using app logs, Tetragon events, and Hubble flows |
+
+Each demo directory has its own README with commands and observation points.

--- a/cilium-demos/canary-progressive-delivery/README.md
+++ b/cilium-demos/canary-progressive-delivery/README.md
@@ -1,0 +1,19 @@
+# Canary progressive delivery demo
+
+This demo uses Cilium Gateway API to split HTTP traffic between a stable classic Pac-Man deployment and an eBee canary deployment. The app exposes version and variant metadata through `/config` and `/version`.
+
+## Run
+
+```bash
+../scripts/deploy-demo.sh canary-progressive-delivery
+kubectl -n pacman-demo get gateway,httproute
+```
+
+## Observe
+
+```bash
+for i in {1..20}; do curl -s http://<gateway-address>/version; echo; done
+hubble observe --namespace pacman-demo --protocol http --follow
+```
+
+Expected result: roughly 80 percent stable responses and 20 percent canary responses.

--- a/cilium-demos/canary-progressive-delivery/canary.yaml
+++ b/cilium-demos/canary-progressive-delivery/canary.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-stable
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/version: stable
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/version: stable
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/version: stable
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_VERSION
+              value: stable
+            - name: APP_VARIANT
+              value: classic
+            - name: APP_COLOR
+              value: "#ffcc00"
+            - name: DB_TYPE
+              value: memory
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-canary
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/version: canary
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/version: canary
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/version: canary
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_VERSION
+              value: canary
+            - name: APP_VARIANT
+              value: ebee
+            - name: APP_COLOR
+              value: "#66ccff"
+            - name: EBEE_MODE
+              value: "true"
+            - name: ALLOW_CLIENT_EBEE_MODE_OVERRIDE
+              value: "false"
+            - name: DB_TYPE
+              value: memory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-stable
+spec:
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/version: stable
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-canary
+spec:
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/version: canary
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: pacman-gateway
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pacman-canary
+spec:
+  parentRefs:
+    - name: pacman-gateway
+  rules:
+    - backendRefs:
+        - name: pacman-stable
+          port: 8080
+          weight: 80
+        - name: pacman-canary
+          port: 8080
+          weight: 20

--- a/cilium-demos/canary-progressive-delivery/kustomization.yaml
+++ b/cilium-demos/canary-progressive-delivery/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - canary.yaml

--- a/cilium-demos/cluster-mesh-failover/README.md
+++ b/cilium-demos/cluster-mesh-failover/README.md
@@ -1,0 +1,34 @@
+# Cluster Mesh failover demo
+
+This demo uses two kind clusters connected with Cilium Cluster Mesh. `pacman-global` is exported as a global shared Service so traffic can fail over between clusters.
+
+## Setup
+
+```bash
+../scripts/setup-clustermesh-kind.sh
+```
+
+Deploy the demo to both clusters:
+
+```bash
+kubectl config use-context kind-pacman-east
+../scripts/deploy-demo.sh cluster-mesh-failover
+kubectl config use-context kind-pacman-west
+../scripts/deploy-demo.sh cluster-mesh-failover
+```
+
+## Fail over
+
+```bash
+./failover.sh
+```
+
+## Observe
+
+```bash
+cilium clustermesh status --context kind-pacman-east
+cilium service list --context kind-pacman-east
+hubble observe --namespace pacman-demo --follow
+```
+
+Expected result: the global service remains discoverable after one cluster's deployment is scaled down.

--- a/cilium-demos/cluster-mesh-failover/clustermesh-demo.yaml
+++ b/cilium-demos/cluster-mesh-failover/clustermesh-demo.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-global
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: APP_VARIANT
+              value: clustermesh-global
+            - name: DB_TYPE
+              value: memory
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-global
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/cilium-demos/cluster-mesh-failover/failover.sh
+++ b/cilium-demos/cluster-mesh-failover/failover.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_A="${CLUSTER_A:-pacman-east}"
+CLUSTER_B="${CLUSTER_B:-pacman-west}"
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+
+kubectl --context "kind-$CLUSTER_A" -n "$NAMESPACE" scale deploy/pacman-global --replicas=0
+kubectl --context "kind-$CLUSTER_A" -n "$NAMESPACE" rollout status deploy/pacman-global --timeout=120s || true
+kubectl --context "kind-$CLUSTER_B" -n "$NAMESPACE" get endpointslices -l kubernetes.io/service-name=pacman-global -o wide

--- a/cilium-demos/cluster-mesh-failover/kustomization.yaml
+++ b/cilium-demos/cluster-mesh-failover/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clustermesh-demo.yaml

--- a/cilium-demos/fault-injection-resilience/README.md
+++ b/cilium-demos/fault-injection-resilience/README.md
@@ -1,0 +1,19 @@
+# Fault injection and resilience demo
+
+The app includes lab-only fault injection middleware. A fault is only injected when `DEMO_SECURITY_MODE=true` and the request has the correct `x-demo-token` header.
+
+## Run
+
+```bash
+../scripts/deploy-demo.sh fault-injection-resilience
+./trigger-fault.sh
+```
+
+## Observe
+
+```bash
+hubble observe --namespace pacman-demo --http-status 503
+kubectl -n pacman-demo logs deploy/pacman-fault-demo
+```
+
+Expected result: the request returns a controlled `503` after the injected delay, and Hubble shows the HTTP error without needing to break the cluster.

--- a/cilium-demos/fault-injection-resilience/fault-demo.yaml
+++ b/cilium-demos/fault-injection-resilience/fault-demo.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-fault-demo
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_VERSION
+              value: fault-demo
+            - name: APP_VARIANT
+              value: resilience
+            - name: DB_TYPE
+              value: memory
+            - name: DEMO_SECURITY_MODE
+              value: "true"
+            - name: DEMO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pacman-demo-token
+                  key: token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pacman-demo-token
+type: Opaque
+stringData:
+  token: pacman-demo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-fault-demo
+spec:
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/cilium-demos/fault-injection-resilience/kustomization.yaml
+++ b/cilium-demos/fault-injection-resilience/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - fault-demo.yaml

--- a/cilium-demos/fault-injection-resilience/trigger-fault.sh
+++ b/cilium-demos/fault-injection-resilience/trigger-fault.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+SERVICE="${SERVICE:-pacman-fault-demo}"
+TOKEN="${DEMO_TOKEN:-pacman-demo}"
+
+kubectl -n "$NAMESPACE" port-forward "svc/$SERVICE" 8080:8080 >/tmp/pacman-fault-port-forward.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" >/dev/null 2>&1 || true' EXIT
+
+for _ in {1..20}; do
+  if curl -fsS http://127.0.0.1:8080/version >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+curl -i \
+  -H "x-demo-token: $TOKEN" \
+  -H "x-demo-fault-delay-ms: 750" \
+  -H "x-demo-fault-status: 503" \
+  http://127.0.0.1:8080/version

--- a/cilium-demos/grpc-grpcroute/README.md
+++ b/cilium-demos/grpc-grpcroute/README.md
@@ -1,0 +1,21 @@
+# gRPC and GRPCRoute demo
+
+This demo is the Kubernetes side of the gRPC use case. It expects an app image with `APP_ROLE=grpc` listening on port `9090` for `pacman.ScoreService`.
+
+## Run
+
+```bash
+../scripts/deploy-demo.sh grpc-grpcroute
+kubectl -n pacman-demo get gateway,grpcroute,svc pacman-grpc
+```
+
+## Observe
+
+Use `grpcurl` against the Gateway address once the app image includes the gRPC server role:
+
+```bash
+grpcurl -plaintext <gateway-address>:9090 list
+hubble observe --namespace pacman-demo --protocol http --follow
+```
+
+The app-side gRPC server is implemented in the application repo; this directory provides the Gateway API wiring for Cilium.

--- a/cilium-demos/grpc-grpcroute/grpcroute.yaml
+++ b/cilium-demos/grpc-grpcroute/grpcroute.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-grpc
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: grpc
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: grpc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: grpc
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: grpc
+              containerPort: 9090
+          env:
+            - name: APP_ROLE
+              value: grpc
+            - name: GRPC_PORT
+              value: "9090"
+            - name: APP_VERSION
+              value: grpc-demo
+            - name: APP_VARIANT
+              value: grpcroute
+            - name: DB_TYPE
+              value: memory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-grpc
+spec:
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: grpc
+  ports:
+    - name: grpc
+      port: 9090
+      targetPort: grpc
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: pacman-grpc-gateway
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: grpc
+      port: 9090
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: pacman-grpc
+spec:
+  parentRefs:
+    - name: pacman-grpc-gateway
+  rules:
+    - matches:
+        - method:
+            service: pacman.ScoreService
+      backendRefs:
+        - name: pacman-grpc
+          port: 9090

--- a/cilium-demos/grpc-grpcroute/kustomization.yaml
+++ b/cilium-demos/grpc-grpcroute/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - grpcroute.yaml

--- a/cilium-demos/kind/cluster-east.yaml
+++ b/cilium-demos/kind/cluster-east.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: none
+  podSubnet: 10.10.0.0/16
+  serviceSubnet: 10.11.0.0/16
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      topology.kubernetes.io/zone: east-a

--- a/cilium-demos/kind/cluster-west.yaml
+++ b/cilium-demos/kind/cluster-west.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: none
+  podSubnet: 10.20.0.0/16
+  serviceSubnet: 10.21.0.0/16
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      topology.kubernetes.io/zone: west-a

--- a/cilium-demos/kind/single-cluster.yaml
+++ b/cilium-demos/kind/single-cluster.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: none
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      topology.kubernetes.io/zone: zone-a
+  - role: worker
+    labels:
+      topology.kubernetes.io/zone: zone-b

--- a/cilium-demos/load-simulation/README.md
+++ b/cilium-demos/load-simulation/README.md
@@ -1,0 +1,78 @@
+# Load simulation demo
+
+This demo adds traffic generators to an existing Pac-Man deployment. Use it after `microservices-east-west` or any demo that exposes a `pacman-web` Service in the same namespace.
+
+It has two layers:
+
+- `pacman-user-simulator`: runs the app image as continuous synthetic users. It fetches the frontend shell, reads config/location, creates user IDs, posts stats, reads highscores, and submits plausible scores.
+- `pacman-k6-load`: runs a finite k6 job for higher-volume HTTP scenario load.
+
+## Run
+
+Deploy a target app first:
+
+```bash
+../scripts/deploy-demo.sh microservices-east-west
+```
+
+Then deploy the simulators:
+
+```bash
+../scripts/deploy-demo.sh load-simulation
+```
+
+The simulator deployment runs continuously. The k6 job ramps up, holds load, and exits.
+
+## Scale frontend pods during load
+
+```bash
+./scale-frontends.sh 6
+kubectl -n pacman-demo get endpointslices -l kubernetes.io/service-name=pacman-web
+```
+
+Scale the simulator itself when you want more source pods and more concurrent sessions:
+
+```bash
+kubectl -n pacman-demo scale deploy/pacman-user-simulator --replicas=5
+```
+
+## Watch traffic
+
+```bash
+./watch-load.sh
+hubble observe --namespace pacman-demo --from-label app.kubernetes.io/component=load-generator --follow
+hubble observe --namespace pacman-demo --to-label app.kubernetes.io/component=web --protocol http
+hubble observe --namespace pacman-demo --to-label app.kubernetes.io/component=score --protocol http
+```
+
+## Tune load
+
+Patch the simulator deployment:
+
+```bash
+kubectl -n pacman-demo set env deploy/pacman-user-simulator USERS=100 MIN_THINK_MS=500 MAX_THINK_MS=2000
+```
+
+Run another k6 job by deleting the completed one and applying the demo again:
+
+```bash
+kubectl -n pacman-demo delete job pacman-k6-load --ignore-not-found
+kubectl -n pacman-demo apply -k .
+```
+
+Useful environment values:
+
+```bash
+PACMAN_BASE_URL=http://pacman-web:8080
+USERS=100
+DURATION_SECONDS=0
+SCORE_SUBMIT_RATE=0.08
+HIGH_SCORE_READ_RATE=0.35
+```
+
+## Demo ideas
+
+- Scale `pacman-web` while load is active and observe Hubble distributing flows across new pods.
+- Roll out the canary demo while k6 is running and compare `/version` responses.
+- Apply stricter CiliumNetworkPolicy and confirm load-generator-to-web is allowed while direct load-generator-to-score is denied.
+- Trigger the fault-injection demo during active sessions and watch retries, failed requests, and latency changes.

--- a/cilium-demos/load-simulation/k6-scenario.yaml
+++ b/cilium-demos/load-simulation/k6-scenario.yaml
@@ -1,0 +1,150 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pacman-k6-scenario
+  labels:
+    app.kubernetes.io/name: pacman-k6
+    app.kubernetes.io/component: load-generator
+data:
+  pacman-user-flow.js: |
+    import http from 'k6/http';
+    import { check, sleep } from 'k6';
+
+    const baseUrl = __ENV.PACMAN_BASE_URL || 'http://pacman-web:8080';
+    const scoreSubmitRate = Number(__ENV.SCORE_SUBMIT_RATE || '0.08');
+    const highScoreReadRate = Number(__ENV.HIGH_SCORE_READ_RATE || '0.35');
+
+    export const options = {
+      scenarios: {
+        pacman_users: {
+          executor: 'ramping-vus',
+          stages: [
+            { duration: __ENV.RAMP_UP || '1m', target: Number(__ENV.USERS || '50') },
+            { duration: __ENV.HOLD || '5m', target: Number(__ENV.USERS || '50') },
+            { duration: __ENV.RAMP_DOWN || '1m', target: 0 },
+          ],
+          gracefulRampDown: '30s',
+        },
+      },
+      thresholds: {
+        http_req_failed: ['rate<0.05'],
+        http_req_duration: ['p(95)<1000'],
+      },
+    };
+
+    function form(fields) {
+      return Object.entries(fields)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+        .join('&');
+    }
+
+    function headers(sessionId) {
+      return {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'user-agent': `k6-pacman-user/${sessionId}`,
+          'x-pacman-simulator-session': String(sessionId),
+        },
+      };
+    }
+
+    function randomIntBetween(min, max) {
+      return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    function randomItem(items) {
+      return items[randomIntBetween(0, items.length - 1)];
+    }
+
+    export default function () {
+      const sessionId = `${__VU}-${__ITER}`;
+      const browserHeaders = headers(sessionId);
+      const staticPaths = ['/', '/style.css', '/pacman-canvas.css', '/pacman-canvas.js', '/config', '/location/metadata'];
+
+      for (const path of staticPaths) {
+        const response = http.get(`${baseUrl}${path}`, browserHeaders);
+        check(response, { [`GET ${path} succeeded`]: (res) => res.status >= 200 && res.status < 400 });
+        sleep(randomIntBetween(1, 4) / 10);
+      }
+
+      const userResponse = http.get(`${baseUrl}/user/id`, browserHeaders);
+      check(userResponse, { 'user id created': (res) => res.status === 200 });
+      const userId = userResponse.json();
+
+      let score = randomIntBetween(100, 1200);
+      const level = randomIntBetween(1, 3);
+      const zone = randomItem(['sim-zone-1', 'sim-zone-2', 'sim-zone-3']);
+      const host = `k6-${__VU}`;
+
+      for (let step = 0; step < randomIntBetween(3, 10); step += 1) {
+        score += randomIntBetween(10, 180);
+        const statsResponse = http.post(
+          `${baseUrl}/user/stats`,
+          form({ userId, cloud: 'synthetic', zone, host, score, level, lives: 3, elapsedTime: step + 1 }),
+          browserHeaders,
+        );
+        check(statsResponse, { 'stats accepted': (res) => res.status === 200 });
+
+        if (Math.random() < highScoreReadRate) http.get(`${baseUrl}/highscores/list`, browserHeaders);
+        if (Math.random() < scoreSubmitRate) {
+          http.post(
+            `${baseUrl}/highscores`,
+            form({ name: `K6${__VU}`, cloud: 'synthetic', zone, host, score, level }),
+            browserHeaders,
+          );
+        }
+        sleep(randomIntBetween(1, 4));
+      }
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pacman-k6-load
+  labels:
+    app.kubernetes.io/name: pacman-k6
+    app.kubernetes.io/component: load-generator
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman-k6
+        app.kubernetes.io/component: load-generator
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k6
+          image: grafana/k6:0.51.0
+          args:
+            - run
+            - /scripts/pacman-user-flow.js
+          env:
+            - name: PACMAN_BASE_URL
+              value: http://pacman-web:8080
+            - name: USERS
+              value: "50"
+            - name: RAMP_UP
+              value: 1m
+            - name: HOLD
+              value: 5m
+            - name: RAMP_DOWN
+              value: 1m
+            - name: SCORE_SUBMIT_RATE
+              value: "0.08"
+            - name: HIGH_SCORE_READ_RATE
+              value: "0.35"
+          volumeMounts:
+            - name: scenario
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: 250m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+      volumes:
+        - name: scenario
+          configMap:
+            name: pacman-k6-scenario

--- a/cilium-demos/load-simulation/kustomization.yaml
+++ b/cilium-demos/load-simulation/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - node-user-simulator.yaml
+  - k6-scenario.yaml

--- a/cilium-demos/load-simulation/node-user-simulator.yaml
+++ b/cilium-demos/load-simulation/node-user-simulator.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-user-simulator
+  labels:
+    app.kubernetes.io/name: pacman-user-simulator
+    app.kubernetes.io/component: load-generator
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman-user-simulator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman-user-simulator
+        app.kubernetes.io/component: load-generator
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: simulator
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - tools/simulate-users.js
+          env:
+            - name: PACMAN_BASE_URL
+              value: http://pacman-web:8080
+            - name: USERS
+              value: "20"
+            - name: DURATION_SECONDS
+              value: "0"
+            - name: MIN_THINK_MS
+              value: "800"
+            - name: MAX_THINK_MS
+              value: "3500"
+            - name: MIN_SESSION_SECONDS
+              value: "45"
+            - name: MAX_SESSION_SECONDS
+              value: "180"
+            - name: SCORE_SUBMIT_RATE
+              value: "0.08"
+            - name: HIGH_SCORE_READ_RATE
+              value: "0.35"
+            - name: METRICS_INTERVAL_SECONDS
+              value: "30"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/cilium-demos/load-simulation/scale-frontends.sh
+++ b/cilium-demos/load-simulation/scale-frontends.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+REPLICAS="${1:-6}"
+
+kubectl -n "$NAMESPACE" scale deploy -l app.kubernetes.io/component=web --replicas="$REPLICAS"
+kubectl -n "$NAMESPACE" rollout status deploy -l app.kubernetes.io/component=web --timeout=180s
+kubectl -n "$NAMESPACE" get deploy,pods -l app.kubernetes.io/component=web -o wide

--- a/cilium-demos/load-simulation/watch-load.sh
+++ b/cilium-demos/load-simulation/watch-load.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+
+kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=load-generator -o wide
+kubectl -n "$NAMESPACE" logs deploy/pacman-user-simulator --tail=40 --prefix=true || true
+kubectl -n "$NAMESPACE" logs job/pacman-k6-load --tail=40 --prefix=true || true

--- a/cilium-demos/microservices-east-west/README.md
+++ b/cilium-demos/microservices-east-west/README.md
@@ -1,0 +1,25 @@
+# Microservices east-west demo
+
+This demo runs one Pac-Man image as three roles: `web`, `score`, and `user`. The browser still talks to the web service, but score and user calls become real east-west Service traffic that Cilium and Hubble can observe and enforce.
+
+## Run
+
+```bash
+../scripts/deploy-demo.sh microservices-east-west
+kubectl -n pacman-demo port-forward svc/pacman-web 8080:8080
+```
+
+Open <http://localhost:8080>, play, and save a score.
+
+## Observe
+
+```bash
+hubble observe --namespace pacman-demo --from-label app.kubernetes.io/component=web --follow
+hubble observe --namespace pacman-demo --to-label app.kubernetes.io/component=score --protocol http
+```
+
+Expected flows include `GET /user/id`, `POST /user/stats`, `GET /highscores/list`, and `POST /highscores` between app roles.
+
+## Policy point
+
+`cilium-network-policy.yaml` allows only web-to-score and web-to-user HTTP paths needed by the app. Try calling an unlisted path on `pacman-score` from another pod and observe a policy drop.

--- a/cilium-demos/microservices-east-west/cilium-network-policy.yaml
+++ b/cilium-demos/microservices-east-west/cilium-network-policy.yaml
@@ -1,0 +1,141 @@
+# Cilium L7 east-west policies for the Pac-Man microservices demo.
+#
+# Web -> score and web -> user traffic is allowed only on the internal
+# east-west paths exposed by the pacman app (and the legacy public proxy
+# paths it forwards from, kept for compatibility). External ingress to web
+# is restricted to the game's static assets and public game APIs.
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pacman-east-west
+specs:
+  # Egress baseline: in-namespace traffic, kube-apiserver, and kube-dns.
+  # Ingress rules are scoped per role below so L7 filters are enforced.
+  - endpointSelector: {}
+    egress:
+      - toEndpoints:
+          - matchLabels: {}
+      - toEntities:
+          - kube-apiserver
+      - toEndpoints:
+          - matchLabels:
+              k8s:io.kubernetes.pod.namespace: kube-system
+        toPorts:
+          - ports:
+              - port: "53"
+                protocol: UDP
+  # External ingress to pacman-web: static assets, health, observability,
+  # and the public game APIs (which the web role forwards to /internal/*).
+  - endpointSelector:
+      matchLabels:
+        app.kubernetes.io/component: web
+    ingress:
+      - toPorts:
+          - ports:
+              - port: "8080"
+                protocol: TCP
+            rules:
+              http:
+                - method: GET
+                  path: "/"
+                - method: GET
+                  path: "/pacman-canvas.js"
+                - method: GET
+                  path: "/pacman-canvas.css"
+                - method: GET
+                  path: "/style.css"
+                - method: GET
+                  path: "/cache.manifest"
+                - method: GET
+                  path: "/data/map.json"
+                - method: GET
+                  path: "/js/.*"
+                - method: GET
+                  path: "/img/.*"
+                - method: GET
+                  path: "/fonts/.*"
+                - method: GET
+                  path: "/mp3/.*"
+                - method: GET
+                  path: "/wav/.*"
+                - method: GET
+                  path: "/healthz"
+                - method: GET
+                  path: "/readyz"
+                - method: GET
+                  path: "/version"
+                - method: GET
+                  path: "/config"
+                - method: POST
+                  path: "/config"
+                - method: GET
+                  path: "/highscores/list"
+                - method: POST
+                  path: "/highscores"
+                - method: GET
+                  path: "/user/id"
+                - method: GET
+                  path: "/user/stats"
+                - method: POST
+                  path: "/user/stats"
+                - method: GET
+                  path: "/metrics"
+  # Web -> score: legacy public paths plus the new /internal/* east-west
+  # paths the web role forwards to when SCORE_SERVICE_URL is configured.
+  - endpointSelector:
+      matchLabels:
+        app.kubernetes.io/component: score
+    ingress:
+      - fromEndpoints:
+          - matchLabels:
+              app.kubernetes.io/component: web
+        toPorts:
+          - ports:
+              - port: "8080"
+                protocol: TCP
+            rules:
+              http:
+                - method: GET
+                  path: /healthz
+                - method: GET
+                  path: /readyz
+                - method: GET
+                  path: /highscores/list
+                - method: POST
+                  path: /highscores
+                - method: GET
+                  path: /internal/score/read
+                - method: POST
+                  path: /internal/score/write
+  # Web -> user: legacy public paths plus the new /internal/* east-west
+  # paths the web role forwards to when USER_SERVICE_URL is configured.
+  - endpointSelector:
+      matchLabels:
+        app.kubernetes.io/component: user
+    ingress:
+      - fromEndpoints:
+          - matchLabels:
+              app.kubernetes.io/component: web
+        toPorts:
+          - ports:
+              - port: "8080"
+                protocol: TCP
+            rules:
+              http:
+                - method: GET
+                  path: /healthz
+                - method: GET
+                  path: /readyz
+                - method: GET
+                  path: /user/id
+                - method: GET
+                  path: /user/stats
+                - method: POST
+                  path: /user/stats
+                - method: GET
+                  path: /internal/user/session
+                - method: GET
+                  path: /internal/user/stats
+                - method: POST
+                  path: /internal/user/stats

--- a/cilium-demos/microservices-east-west/kustomization.yaml
+++ b/cilium-demos/microservices-east-west/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pacman-demo
+
+resources:
+  - workloads.yaml
+  - cilium-network-policy.yaml

--- a/cilium-demos/microservices-east-west/workloads.yaml
+++ b/cilium-demos/microservices-east-west/workloads.yaml
@@ -1,0 +1,220 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-web
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      serviceAccountName: pacman-demo
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_ROLE
+              value: web
+            - name: APP_VERSION
+              value: v1
+            - name: APP_VARIANT
+              value: stable
+            - name: SCORE_SERVICE_URL
+              value: http://pacman-score:8080
+            - name: USER_SERVICE_URL
+              value: http://pacman-user:8080
+            - name: DB_TYPE
+              value: memory
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-score
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: score
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: score
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: score
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_ROLE
+              value: score
+            - name: APP_VERSION
+              value: v1
+            - name: APP_VARIANT
+              value: score-service
+            - name: DB_TYPE
+              value: memory
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-user
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: user
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: user
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: user
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_ROLE
+              value: user
+            - name: APP_VERSION
+              value: v1
+            - name: APP_VARIANT
+              value: user-service
+            - name: DB_TYPE
+              value: memory
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pacman-demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pacman-location-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pacman-location-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pacman-location-reader
+subjects:
+  - kind: ServiceAccount
+    name: pacman-demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pacman-demo-node-reader
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pacman-demo-node-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pacman-demo-node-reader
+subjects:
+  - kind: ServiceAccount
+    name: pacman-demo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-web
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-score
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: score
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: score
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-user
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: user
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: user
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/cilium-demos/runtime-security-incident/README.md
+++ b/cilium-demos/runtime-security-incident/README.md
@@ -1,0 +1,19 @@
+# Runtime security incident demo
+
+This demo creates a safe incident story: a suspicious score attempt is recorded by the app, rejected by server-side validation, visible in logs, and observable alongside Cilium/Hubble traffic.
+
+## Run
+
+```bash
+../scripts/deploy-demo.sh runtime-security-incident
+./trigger-incident.sh
+```
+
+## Observe
+
+```bash
+kubectl -n pacman-demo logs deploy/pacman-incident-demo
+hubble observe --namespace pacman-demo --http-status 400
+```
+
+Expected result: `/demo/incidents` logs a structured incident, and `/highscores` rejects the implausible score with `400`.

--- a/cilium-demos/runtime-security-incident/incident-demo.yaml
+++ b/cilium-demos/runtime-security-incident/incident-demo.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-incident-demo
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_VERSION
+              value: incident-demo
+            - name: APP_VARIANT
+              value: suspicious-score
+            - name: DB_TYPE
+              value: memory
+            - name: DEMO_SECURITY_MODE
+              value: "true"
+            - name: DEMO_TOKEN
+              value: pacman-demo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-incident-demo
+spec:
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/cilium-demos/runtime-security-incident/incident-policy.yaml
+++ b/cilium-demos/runtime-security-incident/incident-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pacman-incident-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: web
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP

--- a/cilium-demos/runtime-security-incident/kustomization.yaml
+++ b/cilium-demos/runtime-security-incident/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - incident-demo.yaml
+  - incident-policy.yaml

--- a/cilium-demos/runtime-security-incident/trigger-incident.sh
+++ b/cilium-demos/runtime-security-incident/trigger-incident.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+TOKEN="${DEMO_TOKEN:-pacman-demo}"
+
+kubectl -n "$NAMESPACE" port-forward svc/pacman-incident-demo 8080:8080 >/tmp/pacman-incident-port-forward.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" >/dev/null 2>&1 || true' EXIT
+
+for _ in {1..20}; do
+  if curl -fsS http://127.0.0.1:8080/version >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+curl -fsS -X POST \
+  -H "content-type: application/json" \
+  -H "x-demo-token: $TOKEN" \
+  -d '{"type":"score-tamper","action":"suspicious-score-submit"}' \
+  http://127.0.0.1:8080/demo/incidents | jq .
+
+curl -i -X POST http://127.0.0.1:8080/highscores -d 'name=CHEATER&score=999999&level=1'

--- a/cilium-demos/scripts/deploy-demo.sh
+++ b/cilium-demos/scripts/deploy-demo.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEMO="${1:?usage: deploy-demo.sh <demo-directory>}"
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+PACMAN_IMAGE="${PACMAN_IMAGE:-docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RENDER_DIR="$(mktemp -d "$ROOT/.deploy-render.XXXXXX")"
+trap 'rm -rf "$RENDER_DIR"' EXIT
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$NAMESPACE" pod-security.kubernetes.io/enforce=baseline --overwrite
+cat > "$RENDER_DIR/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: $NAMESPACE
+resources:
+  - ../$DEMO
+EOF
+kubectl apply -k "$RENDER_DIR"
+
+deployments=$(kubectl -n "$NAMESPACE" get deploy -l app.kubernetes.io/part-of=pacman-cilium-demo -o name)
+
+for deploy in $deployments; do
+  kubectl -n "$NAMESPACE" set image "$deploy" '*='"$PACMAN_IMAGE" >/dev/null || true
+done
+
+for deploy in $deployments; do
+  kubectl -n "$NAMESPACE" rollout status "$deploy" --timeout=180s
+done
+kubectl -n "$NAMESPACE" get pods,svc,gateway,httproute,grpcroute 2>/dev/null || kubectl -n "$NAMESPACE" get pods,svc

--- a/cilium-demos/scripts/setup-clustermesh-kind.sh
+++ b/cilium-demos/scripts/setup-clustermesh-kind.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CILIUM_VERSION="${CILIUM_VERSION:-1.19.4}"
+CLUSTER_A="${CLUSTER_A:-pacman-east}"
+CLUSTER_B="${CLUSTER_B:-pacman-west}"
+
+create_cluster() {
+  local name="$1"
+  local config="$2"
+  if ! kind get clusters | grep -qx "$name"; then
+    kind create cluster --name "$name" --config "$config"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+create_cluster "$CLUSTER_A" "$SCRIPT_DIR/../kind/cluster-east.yaml"
+create_cluster "$CLUSTER_B" "$SCRIPT_DIR/../kind/cluster-west.yaml"
+
+for cluster in "$CLUSTER_A" "$CLUSTER_B"; do
+  kubectl config use-context "kind-$cluster"
+  helm repo add cilium https://helm.cilium.io/ >/dev/null
+  helm repo update >/dev/null
+  helm upgrade --install cilium cilium/cilium \
+    --version "$CILIUM_VERSION" \
+    --namespace kube-system \
+    --set kubeProxyReplacement=true \
+    --set cluster.name="$cluster" \
+    --set cluster.id=$([[ "$cluster" == "$CLUSTER_A" ]] && echo 1 || echo 2) \
+    --set clustermesh.useAPIServer=true \
+    --set hubble.relay.enabled=true \
+    --set hubble.ui.enabled=true \
+    --set ipam.mode=kubernetes
+  cilium status --wait --context "kind-$cluster"
+done
+
+cilium clustermesh enable --context "kind-$CLUSTER_A" --service-type NodePort
+cilium clustermesh enable --context "kind-$CLUSTER_B" --service-type NodePort
+cilium clustermesh connect --context "kind-$CLUSTER_A" --destination-context "kind-$CLUSTER_B"
+cilium clustermesh status --context "kind-$CLUSTER_A" --wait
+cilium clustermesh status --context "kind-$CLUSTER_B" --wait

--- a/cilium-demos/scripts/setup-single-kind.sh
+++ b/cilium-demos/scripts/setup-single-kind.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-pacman-cilium}"
+CILIUM_VERSION="${CILIUM_VERSION:-1.19.4}"
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.4.1}"
+
+if ! kind get clusters | grep -qx "$CLUSTER_NAME"; then
+  kind create cluster --name "$CLUSTER_NAME" --config "$(dirname "$0")/../kind/single-cluster.yaml"
+fi
+
+kubectl config use-context "kind-$CLUSTER_NAME"
+
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml"
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard/gateway.networking.k8s.io_gateways.yaml"
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml"
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml"
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml"
+
+helm repo add cilium https://helm.cilium.io/ --force-update >/dev/null
+helm repo update >/dev/null
+helm upgrade --install cilium cilium/cilium \
+  --version "$CILIUM_VERSION" \
+  --namespace kube-system \
+  --set kubeProxyReplacement=true \
+  --set k8sServiceHost="${CLUSTER_NAME}-control-plane" \
+  --set k8sServicePort=6443 \
+  --set gatewayAPI.enabled=true \
+  --set hubble.relay.enabled=true \
+  --set hubble.ui.enabled=true \
+  --set ipam.mode=kubernetes
+
+cilium status --wait
+
+helm repo add cilium https://helm.cilium.io/ --force-update >/dev/null
+helm upgrade --install tetragon cilium/tetragon \
+  --namespace kube-system \
+  --create-namespace \
+  --wait
+
+kubectl label node "${CLUSTER_NAME}-worker" topology.kubernetes.io/zone=zone-a --overwrite || true
+kubectl label node "${CLUSTER_NAME}-worker2" topology.kubernetes.io/zone=zone-b --overwrite || true

--- a/cilium-demos/tetragon-enforcement/README.md
+++ b/cilium-demos/tetragon-enforcement/README.md
@@ -1,0 +1,20 @@
+# Tetragon enforcement demo
+
+This demo deploys Pac-Man with lab-only incident probes enabled and a Tetragon `TracingPolicy` that observes process execution and file-open activity.
+
+## Run
+
+```bash
+../scripts/deploy-demo.sh tetragon-enforcement
+./trigger-probes.sh
+```
+
+## Observe
+
+```bash
+kubectl -n kube-system logs -l app.kubernetes.io/name=tetragon -c export-stdout --follow
+```
+
+Expected result: the file probe opens `/etc/hostname`, and the exec probe starts a short-lived Node child process. Tetragon should emit process/file events tied to the Pac-Man pod.
+
+The policy is observe-only by default. Add enforcement actions only in a disposable lab.

--- a/cilium-demos/tetragon-enforcement/kustomization.yaml
+++ b/cilium-demos/tetragon-enforcement/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - tetragon-demo.yaml
+  - tracingpolicy.yaml

--- a/cilium-demos/tetragon-enforcement/tetragon-demo.yaml
+++ b/cilium-demos/tetragon-enforcement/tetragon-demo.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-tetragon-demo
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_VERSION
+              value: tetragon-demo
+            - name: APP_VARIANT
+              value: runtime-security
+            - name: DB_TYPE
+              value: memory
+            - name: DEMO_SECURITY_MODE
+              value: "true"
+            - name: DEMO_TOKEN
+              value: pacman-demo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-tetragon-demo
+spec:
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/cilium-demos/tetragon-enforcement/tracingpolicy.yaml
+++ b/cilium-demos/tetragon-enforcement/tracingpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: pacman-demo-process-and-file-observe
+spec:
+  kprobes:
+    - call: security_bprm_check
+      syscall: false
+      return: true
+      args:
+        - index: 0
+          type: linux_binprm
+      selectors:
+        - matchNamespaces:
+            - namespace: Pid
+              operator: In
+              values:
+                - host_ns
+          matchActions:
+            - action: Post
+    - call: security_file_open
+      syscall: false
+      return: true
+      args:
+        - index: 0
+          type: file
+      selectors:
+        - matchActions:
+            - action: Post

--- a/cilium-demos/tetragon-enforcement/trigger-probes.sh
+++ b/cilium-demos/tetragon-enforcement/trigger-probes.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+TOKEN="${DEMO_TOKEN:-pacman-demo}"
+
+kubectl -n "$NAMESPACE" port-forward svc/pacman-tetragon-demo 8080:8080 >/tmp/pacman-tetragon-port-forward.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" >/dev/null 2>&1 || true' EXIT
+
+for _ in {1..20}; do
+  if curl -fsS http://127.0.0.1:8080/version >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+curl -fsS -X POST -H "x-demo-token: $TOKEN" http://127.0.0.1:8080/demo/incidents/file-probe | jq .
+curl -fsS -X POST -H "x-demo-token: $TOKEN" http://127.0.0.1:8080/demo/incidents/exec-probe | jq .

--- a/cilium-demos/topology-aware-routing/README.md
+++ b/cilium-demos/topology-aware-routing/README.md
@@ -1,0 +1,21 @@
+# Topology-aware routing demo
+
+This demo spreads Pac-Man replicas across two kind worker zones and annotates the Service with `service.kubernetes.io/topology-mode: Auto`.
+
+The app reads Kubernetes metadata and displays topology-aware routing details through `/location/metadata` and the game UI.
+
+## Run
+
+```bash
+../scripts/deploy-demo.sh topology-aware-routing
+kubectl -n pacman-demo port-forward svc/pacman-topology 8080:8080
+```
+
+## Observe
+
+```bash
+kubectl -n pacman-demo get endpointslice -l kubernetes.io/service-name=pacman-topology -o yaml
+curl localhost:8080/location/metadata
+```
+
+Look for `topology-aware` in the returned `zone` field when hints or service topology mode are visible to the app.

--- a/cilium-demos/topology-aware-routing/kustomization.yaml
+++ b/cilium-demos/topology-aware-routing/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pacman-demo
+
+resources:
+  - topology-demo.yaml

--- a/cilium-demos/topology-aware-routing/topology-demo.yaml
+++ b/cilium-demos/topology-aware-routing/topology-demo.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pacman-topology
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman-cilium-demo
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pacman
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: pacman-cilium-demo
+    spec:
+      serviceAccountName: pacman-topology
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: pacman
+              app.kubernetes.io/component: web
+      containers:
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: APP_ROLE
+              value: web
+            - name: APP_VERSION
+              value: topology
+            - name: APP_VARIANT
+              value: topology-aware
+            - name: DB_TYPE
+              value: memory
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pacman-topology
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pacman-topology-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pacman-topology-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pacman-topology-reader
+subjects:
+  - kind: ServiceAccount
+    name: pacman-topology
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pacman-topology-node-reader
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pacman-topology-node-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pacman-topology-node-reader
+subjects:
+  - kind: ServiceAccount
+    name: pacman-topology
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pacman-topology
+  labels:
+    app.kubernetes.io/name: pacman
+  annotations:
+    service.kubernetes.io/topology-mode: Auto
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deployments/mongo-deployment.yaml
+++ b/deployments/mongo-deployment.yaml
@@ -1,13 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongo-init
+  labels:
+    app.kubernetes.io/name: mongo
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: pacman
+data:
+  init-user.sh: |
+    #!/bin/bash
+    set -e
+    mongosh "mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@127.0.0.1:27017/admin?authSource=admin" <<EOF
+    use ${APP_DB_NAME};
+    if (!db.getUser("${APP_DB_USER}")) {
+      db.createUser({
+        user: "${APP_DB_USER}",
+        pwd: "${APP_DB_PWD}",
+        roles: [ { role: "readWrite", db: "${APP_DB_NAME}" } ]
+      });
+    }
+    EOF
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     name: mongo
+    app.kubernetes.io/name: mongo
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: pacman
   name: mongo
   annotations:
-    source: "https://github.com/saintdle/pacman-tanzu"
+    source: "https://github.com/saintdle/pacman-for-k8s"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: mongo
@@ -15,71 +44,92 @@ spec:
     metadata:
       labels:
         name: mongo
+        app.kubernetes.io/name: mongo
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: pacman
     spec:
-      initContainers:
-      - args:
-        - |
-          mkdir -p /bitnami/mongodb
-          chown -R "1001:1001" "/bitnami/mongodb"
-        command:
-        - /bin/bash
-        - -ec
-        image: docker.io/bitnami/bitnami-shell:10-debian-10-r158
-        imagePullPolicy: Always
-        name: volume-permissions
-        resources: {}
-        securityContext:
-          runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /bitnami/mongodb
-          name: mongo-db
       restartPolicy: Always
-      schedulerName: default-scheduler
       securityContext:
-        fsGroup: 1001
+        fsGroup: 999
+        runAsUser: 999
+        runAsGroup: 999
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: mongo-db
-        persistentVolumeClaim:
-          claimName: mongo-storage
+        - name: mongo-db
+          persistentVolumeClaim:
+            claimName: mongo-storage
+        - name: mongo-init
+          configMap:
+            name: mongo-init
+            defaultMode: 0755
       containers:
-      - image: bitnami/mongodb:4.4.8
-        name: mongo
-        env:
-        - name: MONGODB_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: database-admin-password
-              name: mongodb-users-secret
-        - name: MONGODB_DATABASE
-          valueFrom:
-            secretKeyRef:
-              key: database-name
-              name: mongodb-users-secret
-        - name: MONGODB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: database-password
-              name: mongodb-users-secret
-        - name: MONGODB_USERNAME
-          valueFrom:
-            secretKeyRef:
-              key: database-user
-              name: mongodb-users-secret
-        readinessProbe:
-          exec:
-           command:
-            - /bin/sh
-            - -i
-            - -c
-            - mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USERNAME -p $MONGODB_PASSWORD
-              --eval="quit()"
-        ports:
-        - name: mongo
-          containerPort: 27017
-        volumeMounts:
-          - name: mongo-db
-            mountPath: /bitnami/mongodb/
+        - image: mongo:8
+          name: mongo
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+          args: ["--bind_ip_all"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: database-admin-name
+                  name: mongodb-users-secret
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: database-admin-password
+                  name: mongodb-users-secret
+            - name: APP_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: database-name
+                  name: mongodb-users-secret
+            - name: APP_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  key: database-user
+                  name: mongodb-users-secret
+            - name: APP_DB_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: database-password
+                  name: mongodb-users-secret
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'mongosh --quiet --eval "db.adminCommand({ ping: 1 }).ok"'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'mongosh --quiet --eval "db.adminCommand({ ping: 1 }).ok"'
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          ports:
+            - name: mongo
+              containerPort: 27017
+          volumeMounts:
+            - name: mongo-db
+              mountPath: /data/db
+            - name: mongo-init
+              mountPath: /docker-entrypoint-initdb.d

--- a/deployments/pacman-deployment.yaml
+++ b/deployments/pacman-deployment.yaml
@@ -1,11 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: pacman
   labels:
     name: pacman
-  name: pacman
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman
   annotations:
-    source: "https://github.com/saintdle/pacman-tanzu"
+    source: "https://github.com/saintdle/pacman-for-k8s"
 spec:
   replicas: 1
   selector:
@@ -15,45 +18,74 @@ spec:
     metadata:
       labels:
         name: pacman
+        app.kubernetes.io/name: pacman
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: pacman
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-      - image: quay.io/ifont/pacman-nodejs-app:latest
-        name: pacman
-        ports:
-        - containerPort: 8080
-          name: http-server
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 8080
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-        env:
-        - name: MONGO_SERVICE_HOST
-          value: mongo
-        - name: MONGO_AUTH_USER
-          valueFrom:
-            secretKeyRef:
-              key: database-user
-              name: mongodb-users-secret
-        - name: MONGO_AUTH_PWD
-          valueFrom:
-            secretKeyRef:
-              key: database-password
-              name: mongodb-users-secret
-        - name: MONGO_DATABASE
-          value: pacman
-        - name: MY_MONGO_PORT
-          value: "27017"
-        - name: MONGO_USE_SSL
-          value: "false"
-        - name: MONGO_VALIDATE_SSL
-          value: "false"
-        - name: MY_NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
+        - name: pacman
+          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8080
+              name: http-server
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-server
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http-server
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          env:
+            - name: DB_TYPE
+              value: mongo
+            - name: MONGO_SERVICE_HOST
+              value: mongo
+            - name: MONGO_AUTH_USER
+              valueFrom:
+                secretKeyRef:
+                  key: database-user
+                  name: mongodb-users-secret
+            - name: MONGO_AUTH_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: database-password
+                  name: mongodb-users-secret
+            - name: MONGO_DATABASE
+              value: pacman
+            - name: MY_MONGO_PORT
+              value: "27017"
+            - name: MONGO_USE_SSL
+              value: "false"
+            - name: MONGO_VALIDATE_SSL
+              value: "false"
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,22 @@
+# Base Kustomization for the classic Mongo-backed deployment.
+# RBAC is intentionally excluded here: pacman-install.sh renders it via
+# envsubst so the ClusterRoleBinding subject namespace matches $NAMESPACE.
+#
+# Usage:
+#   kubectl apply -k . -n pacman-demo
+#   (then apply security/rbac.yaml separately with $NAMESPACE substituted)
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: pacman-demo
+
+commonLabels:
+  app.kubernetes.io/part-of: pacman
+
+resources:
+  - security/secret.yaml
+  - persistentvolumeclaim/mongo-pvc.yaml
+  - deployments/mongo-deployment.yaml
+  - services/mongo-service.yaml
+  - deployments/pacman-deployment.yaml
+  - services/pacman-service.yaml

--- a/pacman-install.sh
+++ b/pacman-install.sh
@@ -1,14 +1,38 @@
-#!/bin/sh
+#!/usr/bin/env bash
+#
+# Idempotent Pac-Man installer (extended deployment, classic Mongo backend).
+# For the multi-role Cilium demos see cilium-demos/scripts/deploy-demo.sh.
+#
+# Honours $NAMESPACE (default: pacman-demo). RBAC is rendered from
+# security/rbac.yaml so the ClusterRoleBinding subject matches $NAMESPACE.
+set -euo pipefail
 
-kubectl create namespace pacman
-kubectl create -n pacman -f security/rbac.yaml
-kubectl create -n pacman -f security/secret.yaml
-kubectl create -n pacman -f persistentvolumeclaim/mongo-pvc.yaml
-kubectl create -n pacman -f deployments/mongo-deployment.yaml
-while [ "$(kubectl get pods -l=name='mongo' -n pacman -o jsonpath='{.items[*].status.containerStatuses[0].ready}')" != "true" ]; do
-   sleep 5
-   echo "Waiting for mongo pod to change to running status"
-done
-kubectl create -n pacman -f deployments/pacman-deployment.yaml
-kubectl create -n pacman -f services/mongo-service.yaml
-kubectl create -n pacman -f services/pacman-service.yaml
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+export NAMESPACE
+
+command -v kubectl   >/dev/null || { echo "kubectl not found"   >&2; exit 1; }
+command -v envsubst  >/dev/null || { echo "envsubst not found (install gettext)" >&2; exit 1; }
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$NAMESPACE" \
+  pod-security.kubernetes.io/enforce=baseline \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/warn=restricted \
+  --overwrite
+
+envsubst < security/rbac.yaml             | kubectl apply -f -
+kubectl apply -n "$NAMESPACE" -f security/secret.yaml
+kubectl apply -n "$NAMESPACE" -f persistentvolumeclaim/mongo-pvc.yaml
+kubectl apply -n "$NAMESPACE" -f deployments/mongo-deployment.yaml
+
+echo "Waiting for mongo pod to become ready..."
+kubectl wait -n "$NAMESPACE" --for=condition=Ready pod \
+  -l name=mongo --timeout=180s
+
+kubectl apply -n "$NAMESPACE" -f services/mongo-service.yaml
+kubectl apply -n "$NAMESPACE" -f deployments/pacman-deployment.yaml
+kubectl apply -n "$NAMESPACE" -f services/pacman-service.yaml
+
+echo
+echo "Install complete in namespace '$NAMESPACE'."
+echo "  kubectl -n $NAMESPACE get pods,svc"

--- a/pacman-uninstall.sh
+++ b/pacman-uninstall.sh
@@ -1,16 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Pac-Man uninstaller. Usage:
+#   ./pacman-uninstall.sh            # remove namespace + PVC
+#   ./pacman-uninstall.sh keeppvc    # keep namespace and PVC (Mongo persistence demo)
+#
+# Honours $NAMESPACE (default: pacman-demo).
+set -euo pipefail
 
-kubectl delete -n pacman -f security/rbac.yaml
-kubectl delete -n pacman -f security/secret.yaml
-kubectl delete -n pacman -f deployments/mongo-deployment.yaml
-kubectl delete -n pacman -f deployments/pacman-deployment.yaml
-kubectl delete -n pacman -f services/mongo-service.yaml
-kubectl delete -n pacman -f services/pacman-service.yaml
+NAMESPACE="${NAMESPACE:-pacman-demo}"
+export NAMESPACE
+MODE="${1:-}"
 
-if [[ $# -gt 0  && "$1" == "keeppvc" ]]
-then
-    echo "Keeping namespace and persistent volume claim"
+command -v kubectl  >/dev/null || { echo "kubectl not found"  >&2; exit 1; }
+command -v envsubst >/dev/null || { echo "envsubst not found" >&2; exit 1; }
+
+# Cluster-scoped RBAC, always removed (subject is namespaced).
+envsubst < security/rbac.yaml | kubectl delete --ignore-not-found -f -
+
+if [[ "$MODE" == "keeppvc" ]]; then
+  echo "Removing workloads in '$NAMESPACE' (keeping PVC and namespace)..."
+  kubectl -n "$NAMESPACE" delete --ignore-not-found -f services/pacman-service.yaml
+  kubectl -n "$NAMESPACE" delete --ignore-not-found -f deployments/pacman-deployment.yaml
+  kubectl -n "$NAMESPACE" delete --ignore-not-found -f services/mongo-service.yaml
+  kubectl -n "$NAMESPACE" delete --ignore-not-found -f deployments/mongo-deployment.yaml
+  kubectl -n "$NAMESPACE" delete --ignore-not-found -f security/secret.yaml
+  echo "Done. Mongo PVC retained:"
+  kubectl -n "$NAMESPACE" get pvc
 else
-    kubectl delete -n pacman -f persistentvolumeclaim/mongo-pvc.yaml
-    kubectl delete namespace pacman
+  echo "Removing namespace '$NAMESPACE' (including PVC)..."
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found
 fi

--- a/persistentvolumeclaim/mongo-pvc.yaml
+++ b/persistentvolumeclaim/mongo-pvc.yaml
@@ -1,8 +1,11 @@
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: mongo-storage
-  namespace: pacman
+  labels:
+    app.kubernetes.io/name: mongo
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: pacman
 spec:
   accessModes:
     - ReadWriteOnce

--- a/security/rbac.yaml
+++ b/security/rbac.yaml
@@ -1,68 +1,34 @@
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: pacman
-spec:
-  privileged: true
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  runAsUser:
-    rule: RunAsAny
-  fsGroup:
-    rule: RunAsAny
-  volumes:
-  - '*'
+# Pac-Man RBAC. The legacy PodSecurityPolicy (policy/v1beta1) was removed
+# in Kubernetes 1.25; pod-level security is now enforced by Pod Security
+# Standards labels on the namespace (see pacman-install.sh).
+#
+# This template is rendered by pacman-install.sh via `envsubst` so the
+# ClusterRoleBinding subject namespace matches $NAMESPACE.
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pacman-clusterrole
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/part-of: pacman
 rules:
-- apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-  resourceNames:
-  - pacman
-- apiGroups: [""]
-  resources: ["pods", "nodes"]
-  verbs: ["get", "watch", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: pacman-clusterrole
-  namespace: pacman
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: pacman-clusterrole
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:serviceaccounts
-- kind: ServiceAccount
-  name: default
-  namespace: pacman
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pacman-clusterrole
-  namespace: pacman
+  name: pacman-clusterrole-${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/part-of: pacman
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: pacman-clusterrole
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:serviceaccounts
-- kind: ServiceAccount
-  name: default
-  namespace: pacman
----
+  - kind: ServiceAccount
+    name: default
+    namespace: ${NAMESPACE}

--- a/security/secret.yaml
+++ b/security/secret.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mongodb-users-secret
-  namespace: pacman
 type: Opaque 
 data:
   database-admin-name: Y2x5ZGU=

--- a/services/mongo-service.yaml
+++ b/services/mongo-service.yaml
@@ -1,13 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: mongo
   labels:
     name: mongo
-  name: mongo
+    app.kubernetes.io/name: mongo
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: pacman
 spec:
   type: ClusterIP
   ports:
     - port: 27017
       targetPort: 27017
+      name: mongo
   selector:
     name: mongo

--- a/services/pacman-service.yaml
+++ b/services/pacman-service.yaml
@@ -4,11 +4,15 @@ metadata:
   name: pacman
   labels:
     name: pacman
+    app.kubernetes.io/name: pacman
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: pacman
 spec:
   type: LoadBalancer
   ports:
     - port: 80
       targetPort: 8080
       protocol: TCP
+      name: http
   selector:
     name: pacman


### PR DESCRIPTION
This PR brings the deployment surface up to date with current Kubernetes and Cilium practice and adds a catalogue of Cilium-focused demos that build on the same Pac-Man app.

It is the deployment-focused companion to the app modernization in [`saintdle/pacman#1`](https://github.com/saintdle/pacman/pull/1). All workloads use the published image from Docker Hub, pinned by digest: `docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198`.

## Base deployment

- Default namespace is now `pacman-demo` across `pacman-install.sh` and `pacman-uninstall.sh`, both honour a `NAMESPACE` env override
- Drop hard-coded `namespace: pacman` from the PVC and Secret manifests so the install/uninstall scripts are authoritative
- Install script labels the namespace with Pod Security Standards (`enforce=baseline`, `audit/warn=restricted`)
- Mongo deployment rewritten:
  - Switched from `bitnami/mongodb` (Bitnami no longer publishes versioned free tags) to the official `mongo:8` image
  - New `mongo-init` ConfigMap mounted at `/docker-entrypoint-initdb.d` creates the application user via `createUser` (idempotent)
  - `runAsNonRoot`, `runAsUser`/`fsGroup` `999`, `--bind_ip_all`, `/data/db` PVC mount
  - `strategy.type: Recreate` so rollouts do not race the RWO PVC lock
- `pacman-deployment.yaml` pinned to the digest above, probes use `/healthz` and `/readyz`, `DB_TYPE=mongo` env added
- Drop the `policy/v1beta1 PodSecurityPolicy` ClusterRole (PSP is removed in Kubernetes 1.25+), keep a minimal `pods`/`nodes` read ClusterRole bound to the default ServiceAccount

## Cilium demos catalogue (new `cilium-demos/`)

- `microservices-east-west`: 3-role deployment with a `CiliumNetworkPolicy` enforcing L7 access between web, score, and user (explicit per-role ingress, DNS + kube-apiserver egress)
- `canary-progressive-delivery`, `grpc-grpcroute`, `cluster-mesh-failover`, `fault-injection-resilience`, `runtime-security-incident`, `tetragon-enforcement`, `topology-aware-routing`, `load-simulation`
- `scripts/deploy-demo.sh` helper, `kind` cluster configs (single and east/west), and per-demo README + kustomization + helper scripts
- All demo workloads use the same pinned `saintdle/pacman` digest

## Validation

- Base stack deployed live to a kind cluster: `mongo:8` boots, init script creates the app user, the `pacman` pod connects with `DB_TYPE=mongo`. Two scores POSTed via the K8s `pacman` Service round-tripped through the app and persisted as documents in the `pacman.highscore` collection. After a force pod delete + redeploy, the records survived (PVC durability).
- `microservices-east-west` deployed live: L7 enforcement confirmed end-to-end. Allowed paths return `200` from Envoy, paths not in the policy (`/metrics`, `/version` on the score deployment) return `403`.